### PR TITLE
refactor: rename repository from camp to monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ About you: @.agents/prompts/mode-max-eng.md
 
 ## Repository Overview
 
-This is the `@outfitter/camp` monorepo - a collection of shared configurations
+This is the `@outfitter/monorepo` - a collection of shared configurations
 and utilities for Outfitter projects. It uses pnpm workspaces and contains 8
 packages that provide development tools, configurations, and coding standards.
 
@@ -95,7 +95,7 @@ The monorepo follows a clear separation of concerns:
    - `changeset-config`: Release management configuration
 
 3. **Tools & Documentation**:
-   - `cli`: Command-line tool that consumes packlist as a library
+   - `cli`: Command-line tool (globally installable as `outfitter`) that consumes packlist as a library
    - `fieldguides`: Living documentation system with content in `content/`
      subdirectory
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @outfitter/camp
+# @outfitter/monorepo
 
 Core shared configurations and utilities for Outfitter projects.
 
@@ -10,7 +10,7 @@ This monorepo contains the following packages:
 
 - **[@outfitter/packlist](./packages/packlist)** - Unified development
   configuration manager
-- **[@outfitter/typescript-utils](./packages/typescript-utils)** - Type-safe
+- **[@outfitter/contracts](./packages/contracts/typescript)** - Type-safe
   utility functions and error handling
 
 ### Development Configurations

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Architecture Documentation
 
-This directory contains architectural documentation for the Camp monorepo.
+This directory contains architectural documentation for the Outfitter monorepo.
 
 ## Contents
 

--- a/docs/architecture/cli-and-packlist.md
+++ b/docs/architecture/cli-and-packlist.md
@@ -6,10 +6,10 @@ configuration management system.
 
 ## Overview
 
-The Camp monorepo contains two complementary packages for configuration
+The Outfitter monorepo contains two complementary packages for configuration
 management:
 
-- **`@outfitter/cli`**: User-facing command-line interface (the `camp` command)
+- **`@outfitter/cli`**: User-facing command-line interface (the `outfitter` command)
 - **`@outfitter/packlist`**: Core configuration engine and programmatic API
 
 ## Architecture Design
@@ -71,12 +71,12 @@ management:
 
 ## How They Work Together
 
-### Example: `camp init` Command
+### Example: `outfitter packlist init` Command
 
 ```typescript
 // CLI Layer (packages/cli/src/commands/init.ts)
 import { init } from '@outfitter/packlist';
-import { isSuccess } from '@outfitter/typescript-utils';
+import { isSuccess } from '@outfitter/contracts';
 
 export async function initCommand(options: InitOptions) {
   // 1. CLI handles user interaction
@@ -265,5 +265,5 @@ The separation between CLI and Packlist provides:
 4. **Flexibility**: CLI can be replaced without changing core logic
 5. **Type safety**: Result pattern ensures error handling
 
-This architecture allows the Camp monorepo to provide both an excellent user
+This architecture allows the Outfitter monorepo to provide both an excellent user
 experience through the CLI and a robust programmatic API through Packlist.

--- a/docs/architecture/monorepo-design.md
+++ b/docs/architecture/monorepo-design.md
@@ -1,8 +1,8 @@
-# Camp Monorepo Architecture
+# Outfitter Monorepo Architecture
 
 ## Overview
 
-Camp is structured as a monorepo containing shared development configurations,
+The Outfitter monorepo is structured as a monorepo containing shared development configurations,
 utilities, and tools for Outfitter projects. This document outlines the
 architectural decisions behind this structure.
 
@@ -10,15 +10,15 @@ architectural decisions behind this structure.
 
 ### 1. Zero-Dependency Core
 
-The `@outfitter/typescript-utils` package maintains zero runtime dependencies,
+The `@outfitter/contracts` package maintains zero runtime dependencies,
 serving as the foundational error handling layer for all other packages.
 
 ### 2. Clear Build Order
 
 TypeScript project references enforce a clear dependency graph:
 
-- `typescript-utils` builds first (no dependencies)
-- All other packages may depend on `typescript-utils`
+- `contracts` builds first (no dependencies)
+- All other packages may depend on `contracts`
 - Circular dependencies are prohibited
 
 ### 3. Workspace Protocol
@@ -35,7 +35,7 @@ All internal dependencies use `workspace:*` protocol to ensure:
 
 Located in `packages/`, these provide shared functionality:
 
-- **typescript-utils**: Result pattern and error handling
+- **contracts**: Result pattern and error handling
 - **packlist**: Configuration orchestration
 - **eslint-config**: Shared linting rules
 - **typescript-config**: Base TypeScript configurations
@@ -44,7 +44,7 @@ Located in `packages/`, these provide shared functionality:
 
 Command-line tools and utilities:
 
-- **cli**: The `camp` command for managing configurations
+- **cli**: The `outfitter` command for managing configurations
 - **husky-config**: Git hooks setup
 
 ### Documentation Package

--- a/docs/architecture/package-boundaries.md
+++ b/docs/architecture/package-boundaries.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines how packages in the Camp monorepo are organized, their
+This document defines how packages in the Outfitter monorepo are organized, their
 responsibilities, and their interaction patterns.
 
 ## Package Categories
@@ -31,7 +31,7 @@ responsibilities, and their interaction patterns.
 
 **Examples**:
 
-- `@outfitter/typescript-utils`
+- `@outfitter/contracts`
 - `@outfitter/packlist`
 
 **Characteristics**:

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,6 +1,6 @@
-# Contributing to Camp
+# Contributing to the Outfitter Monorepo
 
-Welcome to the Camp monorepo contributing guide!
+Welcome to the Outfitter monorepo contributing guide!
 
 ## Guides
 
@@ -18,8 +18,8 @@ Welcome to the Camp monorepo contributing guide!
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/outfitter-dev/camp
-   cd camp
+   git clone https://github.com/outfitter-dev/monorepo
+   cd monorepo
    ```
 
 2. **Install dependencies**:

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide covers development workflows for the Camp monorepo and all its
+This guide covers development workflows for the Outfitter monorepo and all its
 packages.
 
 ## Prerequisites
@@ -13,8 +13,8 @@ packages.
 
 ```bash
 # Clone the repository
-git clone https://github.com/outfitter-dev/camp
-cd camp
+git clone https://github.com/outfitter-dev/monorepo
+cd monorepo
 
 # Install dependencies
 pnpm install
@@ -34,7 +34,7 @@ Due to TypeScript project references, packages must build in order:
 pnpm build
 
 # Build specific package
-pnpm build --filter @outfitter/typescript-utils
+pnpm build --filter @outfitter/contracts
 
 # Build with dependencies
 pnpm build --filter @outfitter/cli...
@@ -42,8 +42,8 @@ pnpm build --filter @outfitter/cli...
 
 **Build Order**:
 
-1. `typescript-utils` (no dependencies)
-2. All other packages (may depend on typescript-utils)
+1. `contracts` (no dependencies)
+2. All other packages (may depend on contracts)
 
 ### 2. Testing
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -58,7 +58,7 @@ pnpm test --run
 pnpm test --filter @outfitter/packlist
 
 # Run specific test file
-pnpm test packages/typescript-utils/src/__tests__/result.test.ts
+pnpm test packages/contracts/typescript/src/__tests__/result.test.ts
 ```
 
 ### 3. Linting and Formatting

--- a/docs/decisions/001-keep-cli-as-package.md
+++ b/docs/decisions/001-keep-cli-as-package.md
@@ -2,12 +2,12 @@
 
 **Status**: Accepted  
 **Date**: 2025-01-06  
-**Deciders**: Camp maintainers
+**Deciders**: Outfitter monorepo maintainers
 
 ## Context
 
 The `@outfitter/cli` currently resides in `packages/cli/` and provides the
-`camp` command for managing development configurations. As the monorepo evolves,
+`outfitter` command for managing development configurations. As the monorepo evolves,
 we need to decide whether it should remain a package or move to an `apps/`
 directory.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@outfitter/camp",
+  "name": "@outfitter/monorepo",
   "version": "0.0.0",
   "description": "Core shared configurations and utilities for Outfitter projects",
   "private": true,
@@ -45,10 +45,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git"
+    "url": "https://github.com/outfitter-dev/monorepo.git"
   },
-  "homepage": "https://github.com/outfitter-dev/camp#readme",
+  "homepage": "https://github.com/outfitter-dev/monorepo#readme",
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   }
 }

--- a/packages/changeset-config/README.md
+++ b/packages/changeset-config/README.md
@@ -70,7 +70,7 @@ pnpm changeset:publish
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/changeset-config/package.json
+++ b/packages/changeset-config/package.json
@@ -34,13 +34,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/changeset-config"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/changeset-config#readme",
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/changeset-config#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -7,7 +7,7 @@ code in this repository.
 
 This is the `@outfitter/cli` package - a command-line tool for managing
 Outfitter supplies (development standards, patterns, and guides) in projects.
-It's part of the `@outfitter/camp` monorepo and provides commands to initialize
+It's part of the `@outfitter/monorepo` and provides commands to initialize
 projects, add/update supplies, and manage supply configurations (packlists).
 
 ## Key Commands

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -182,7 +182,7 @@ standards and patterns.
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo).
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,11 +51,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/cli#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/cli#readme"
 }

--- a/packages/contracts/typescript/README.md
+++ b/packages/contracts/typescript/README.md
@@ -283,7 +283,7 @@ The `@outfitter/contracts/zod` sub-path has a peer dependency on `zod`.
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 ```bash
 # Install dependencies

--- a/packages/contracts/typescript/package.json
+++ b/packages/contracts/typescript/package.json
@@ -46,11 +46,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/typescript-utils"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/typescript-utils#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/contracts/typescript#readme"
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -91,7 +91,7 @@ config, see the
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,11 +31,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/eslint-config"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/eslint-config#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/eslint-config#readme"
 }

--- a/packages/fieldguides/content/guides/coderabbit-guide.md
+++ b/packages/fieldguides/content/guides/coderabbit-guide.md
@@ -35,7 +35,7 @@ profile: "chill" # Preferred for most projects
 # - Training juniors → Detailed feedback helps
 # - AI agent workflows → Structured output needed
 # - Large teams → Consistency enforcement critical
-profile: "assertive"
+profile: "assertive" # Comprehensive feedback mode
 ```
 
 ### Tool Selection Strategy

--- a/packages/fieldguides/content/guides/coderabbit-guide.md
+++ b/packages/fieldguides/content/guides/coderabbit-guide.md
@@ -28,7 +28,7 @@ different project types with structured output for AI implementation.
 # - Small team or solo → Less noise preferred
 # - Mature codebase → Good practices established
 # - Open source → Community-friendly approach
-profile: "chill"
+profile: "chill" # Preferred for most projects
 
 # Use "assertive" profile when:
 # - Security-critical apps → Every issue matters

--- a/packages/fieldguides/package.json
+++ b/packages/fieldguides/package.json
@@ -60,11 +60,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/fieldguides"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/fieldguides#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/fieldguides#readme"
 }

--- a/packages/husky-config/README.md
+++ b/packages/husky-config/README.md
@@ -125,7 +125,7 @@ quality standards.
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/husky-config/package.json
+++ b/packages/husky-config/package.json
@@ -34,13 +34,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/husky-config"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/husky-config#readme",
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/husky-config#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/packlist/README.md
+++ b/packages/packlist/README.md
@@ -135,7 +135,7 @@ Packlist creates a `.packlist.json` file to track your project's configuration:
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/packlist/package.json
+++ b/packages/packlist/package.json
@@ -44,11 +44,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/packlist"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/packlist#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/packlist#readme"
 }

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -152,7 +152,7 @@ strict settings, see the
 ## Development
 
 This package is part of the
-[@outfitter/camp](https://github.com/outfitter-dev/camp) monorepo.
+[@outfitter/monorepo](https://github.com/outfitter-dev/monorepo) monorepo.
 
 See the [Development Guide](../../docs/contributing/development.md) for
 instructions on building, testing, and contributing to this package.

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -22,11 +22,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/camp.git",
+    "url": "https://github.com/outfitter-dev/monorepo.git",
     "directory": "packages/typescript-config"
   },
   "bugs": {
-    "url": "https://github.com/outfitter-dev/camp/issues"
+    "url": "https://github.com/outfitter-dev/monorepo/issues"
   },
-  "homepage": "https://github.com/outfitter-dev/camp/tree/main/packages/typescript-config#readme"
+  "homepage": "https://github.com/outfitter-dev/monorepo/tree/main/packages/typescript-config#readme"
 }


### PR DESCRIPTION
## Summary

This PR implements a comprehensive renaming of the repository from "camp" to "monorepo" to better reflect its purpose and contents.

## Changes Made

### Repository & Package Naming
- Updated repository name from `@outfitter/camp` to `@outfitter/monorepo`
- Updated all repository URLs from `camp.git` to `monorepo.git`
- Updated package references from `typescript-utils` to `contracts`

### Documentation Updates
- Updated all documentation references from "Camp" to "Outfitter monorepo"
- Updated architecture documentation to reflect new naming
- Updated contributing guidelines with new repository references
- Updated package-specific README files across all 8 packages

### Configuration Updates
- Updated root `package.json` with new name and repository URLs
- Updated all package `package.json` files with consistent repository references
- Updated project references and internal documentation

## Rationale

The "camp" name was a temporary metaphor that didn't clearly communicate the repository's purpose. "Monorepo" is more descriptive and aligns with industry terminology for multi-package repositories containing shared configurations and utilities.

## Test Plan

- [x] All changes are documentation and configuration updates
- [x] No functional code changes that require testing
- [x] Repository structure and build process remain unchanged
- [x] Package dependencies and references updated consistently

🤖 Generated with [Claude Code](https://claude.ai/code)