### PR TITLE
fix: add GitHub Actions permissions for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The GitHub Actions workflow is failing with a 403 permission error when trying to publish packages via changesets:

```
remote: Permission to outfitter-dev/monorepo.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/outfitter-dev/monorepo/': The requested URL returned error: 403
```

## Solution

Add explicit permissions to the workflow in `.github/workflows/publish.yml`:

```yaml
permissions:
  contents: write        # For creating commits and tags
  pull-requests: write   # For creating release PRs
  id-token: write       # For npm publishing
```

## Impact

After merging this PR, the workflow will be able to:
- ✅ Apply changesets and create release commits
- ✅ Publish packages to npm
- ✅ Create GitHub releases and tags

## Background

This is needed because the repository likely has restricted default permissions for GitHub Actions tokens. The explicit permissions override this restriction for the publishing workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)