### PR TITLE
feat(changeset): link related packages for coordinated versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,10 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    ["@outfitter/contracts", "@outfitter/contracts-zod"],
+    ["@outfitter/eslint-config", "@outfitter/typescript-config"]
+  ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Summary

This PR configures changesets to link related packages for coordinated versioning.

## Changes

- **Linked @outfitter/contracts with @outfitter/contracts-zod**
  - These packages are tightly coupled (contracts-zod depends on contracts)
  - Breaking changes in contracts require updates to contracts-zod
  
- **Linked @outfitter/eslint-config with @outfitter/typescript-config**
  - Core development configurations that benefit from consistency
  - Often updated together for coordinated tooling updates

## How It Works

With linked packages:
- **Major and minor versions** are synchronized within each group
- **Patch versions** can still be independent

Examples:
- Breaking change to contracts (2.0.0) → contracts-zod also goes to 2.0.0
- New feature in eslint-config (1.1.0) → typescript-config also goes to 1.1.0  
- Bug fix in only typescript-config → can go to 1.0.5 while eslint-config stays at 1.0.4

## Benefits

- Ensures version compatibility for tightly coupled packages
- Maintains consistency for related development tools
- Still allows independent patch releases for bug fixes