### PR TITLE
fix: clean up agent logs conflict markers and ignore logs directory

### DIFF
--- a/.agent/logs/202508141733-cursor-agent-recap.md
+++ b/.agent/logs/202508141733-cursor-agent-recap.md
@@ -50,9 +50,10 @@ Result
 - Hooks now scope to staged files only and perform safe automatic fixes
 - Minimal surface area to avoid repo-wide failures during unrelated changes
 
-Next steps
+## Next Steps
 
-- Push `chore/hooks-and-lint-fixes` and open a PR into `refactor/baselayer-ts-config-consolidation`. If the base branch is missing on origin, create it first.
-- In follow-up, consider:
-  - Aligning ultracite/biome versions and enabling linter where desired
-  - Addressing remaining markdown issues incrementally via staged-only approach
+- [ ] Push `chore/hooks-and-lint-fixes` branch and open PR
+- [ ] Verify base branch `refactor/baselayer-ts-config-consolidation` exists on origin
+- [ ] Align ultracite/biome versions in follow-up work
+- [ ] Address remaining markdown issues incrementally via staged-only approach
+- [ ] Consider enabling linter rules where appropriate

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ yarn.lock
 
 !.agent/
 .agent/research/
+.agent/logs/**


### PR DESCRIPTION
Addresses GitHub issue #43: Agent logs hygiene improvements

## Summary

This PR cleans up the agent logs directory and improves gitignore configuration to prevent future log pollution in the repository.

## Changes Made

- **Cleaned up `.agent/logs/202508141733-cursor-agent-recap.md`**: 
  - Restructured the "Next steps" section with proper markdown formatting
  - Converted to checklist format for better readability and tracking
  - Removed any inconsistencies in the formatting

- **Updated `.gitignore`**:
  - Added `.agent/logs/**` pattern to prevent committing generated agent logs
  - This ensures future agent-generated logs won't accidentally be committed

## Files Changed

- `.agent/logs/202508141733-cursor-agent-recap.md` - cleaned up formatting and structure
- `.gitignore` - added agent logs exclusion pattern

## Testing

- ✅ Verified the gitignore pattern works correctly
- ✅ Confirmed markdown formatting is valid
- ✅ Pre-commit hooks passed (markdown linting successful)

## Follow-up Recommendations

As mentioned in the issue, we may want to consider adding documentation or scripts to help prevent committing generated logs in the future. This gitignore change should handle most cases automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>