### PR TITLE
fix: streamline github actions to prevent duplicate claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,13 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [ready_for_review]  # Only trigger when PR becomes ready (not draft)
+    types: [opened]  # Trigger when PR is first opened
   issue_comment:
     types: [created]
 
 jobs:
   claude-review:
-    # Run on ready_for_review OR when someone comments "@claude review"
+    # Run on PR open OR when someone comments "@claude review"
     # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
@@ -42,14 +42,25 @@ jobs:
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide feedback on:
+            ${{ contains(github.event.comment.body, '@claude review latest') || contains(github.event.comment.body, '@claude review recent') && 
+            'Please perform an incremental review focusing ONLY on the changes made since your last review. Look at the most recent commits and provide feedback specifically on what has changed.' ||
+            'Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
+            - Documentation consistency: Verify that README.md and other docs reflect any code changes
             
-            Be constructive and helpful in your feedback.
+            Be constructive and specific in your feedback. Give inline comments where applicable.
+            
+            ---
+            💡 **For future reviews on this PR**, you can request:
+            - `@claude review` - Full review of all changes
+            - `@claude review latest` or `@claude review recent` - Incremental review of only the newest changes since last review' }}
+          
+          # MCP tools for creating proper GitHub PR reviews with inline comments
+          allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
@@ -76,16 +87,21 @@ jobs:
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
 
-# This workflow will only run automatically when:
-# 1. A PR transitions from draft to ready for review
-# 2. Someone explicitly comments "@claude review" on a PR
+# This workflow runs automatically when:
+# 1. A PR is first opened (not draft)
+# 2. Someone comments "@claude review" on a PR
+# 
+# Review types:
+# - Initial open: Full review with instructions for future reviews
+# - "@claude review": Full review of all changes
+# - "@claude review latest" or "@claude review recent": Incremental review of newest changes only
 # 
 # Allowed comment sources:
 # - All human users
 # - Specific bots: @copilot[bot], @devin[bot], @coderabbitai[bot]
 # 
 # It will NOT run on:
-# - New commits to existing PRs
+# - New commits to existing PRs (unless manually triggered)
 # - Draft PRs
 # - Other bot comments (except the allowed ones)
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,8 +10,6 @@ jobs:
   claude-review:
     # Run on PR events (open, ready_for_review, review_requested) OR when someone comments "@claude review"
     # Allow specific bots (@copilot[bot], @devin[bot], @coderabbitai[bot]) and all humans
-    env:
-      ALLOWED_BOTS: '["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
@@ -19,7 +17,7 @@ jobs:
        github.event.comment &&
        contains(github.event.comment.body, '@claude review') &&
        (github.event.comment.user.type != 'Bot' ||
-        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login)))
+        contains(fromJSON('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'), github.event.comment.user.login)))
     
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,13 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]  # Trigger when PR is first opened
+    types: [opened, ready_for_review, review_requested]  # Trigger on open, draft→ready, or review request
   issue_comment:
     types: [created]
 
 jobs:
   claude-review:
-    # Run on PR open OR when someone comments "@claude review"
+    # Run on PR events (open, ready_for_review, review_requested) OR when someone comments "@claude review"
     # Allow specific bots (@copilot[bot], @devin[bot], @coderabbitai[bot]) and all humans
     env:
       ALLOWED_BOTS: '["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'
@@ -95,7 +95,9 @@ jobs:
 
 # This workflow runs automatically when:
 # 1. A PR is first opened (not draft)
-# 2. Someone comments "@claude review" on a PR
+# 2. A draft PR is marked as ready for review
+# 3. Someone requests a review on the PR
+# 4. Someone comments "@claude review" on a PR
 #
 # Review types:
 # - Initial open: Full review with instructions for future reviews

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,9 +16,7 @@ jobs:
        github.event.issue.pull_request && 
        contains(github.event.comment.body, '@claude review') &&
        (github.event.comment.user.type != 'Bot' || 
-        github.event.comment.user.login == 'copilot[bot]' ||
-        github.event.comment.user.login == 'devin[bot]' ||
-        github.event.comment.user.login == 'coderabbitai[bot]'))
+        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login)))
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,11 +9,16 @@ on:
 jobs:
   claude-review:
     # Run on ready_for_review OR when someone comments "@claude review"
+    # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request && 
-       contains(github.event.comment.body, '@claude review'))
+       contains(github.event.comment.body, '@claude review') &&
+       (github.event.comment.user.type != 'Bot' || 
+        github.event.comment.user.login == 'copilot[bot]' ||
+        github.event.comment.user.login == 'devin[bot]' ||
+        github.event.comment.user.login == 'coderabbitai[bot]'))
     
     runs-on: ubuntu-latest
     permissions:
@@ -77,9 +82,12 @@ jobs:
 # 1. A PR transitions from draft to ready for review
 # 2. Someone explicitly comments "@claude review" on a PR
 # 
+# Allowed comment sources:
+# - All human users
+# - Specific bots: @copilot[bot], @devin[bot], @coderabbitai[bot]
+# 
 # It will NOT run on:
 # - New commits to existing PRs
 # - Draft PRs
-# - CodeRabbit comments
-# - Other bot comments
+# - Other bot comments (except the allowed ones)
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,21 +9,27 @@ on:
 jobs:
   claude-review:
     # Run on PR open OR when someone comments "@claude review"
-    # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans
+    # Allow specific bots (@copilot[bot], @devin[bot], @coderabbitai[bot]) and all humans
+    env:
+      ALLOWED_BOTS: '["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && 
-       github.event.issue.pull_request && 
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude review') &&
-       (github.event.comment.user.type != 'Bot' || 
-        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login)))
+       (github.event.comment.user.type != 'Bot' ||
+        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login)))
     
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read  # Required for Claude to read CI results
     
     steps:
       - name: Checkout repository
@@ -90,18 +96,17 @@ jobs:
 # This workflow runs automatically when:
 # 1. A PR is first opened (not draft)
 # 2. Someone comments "@claude review" on a PR
-# 
+#
 # Review types:
 # - Initial open: Full review with instructions for future reviews
 # - "@claude review": Full review of all changes
 # - "@claude review latest" or "@claude review recent": Incremental review of newest changes only
-# 
+#
 # Allowed comment sources:
 # - All human users
 # - Specific bots: @copilot[bot], @devin[bot], @coderabbitai[bot]
-# 
+#
 # It will NOT run on:
 # - New commits to existing PRs (unless manually triggered)
 # - Draft PRs
 # - Other bot comments (except the allowed ones)
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [ready_for_review]  # Only trigger when PR becomes ready (not draft)
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Run on ready_for_review OR when someone comments "@claude review"
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request && 
+       contains(github.event.comment.body, '@claude review'))
     
     runs-on: ubuntu-latest
     permissions:
@@ -75,4 +72,14 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
+
+# This workflow will only run automatically when:
+# 1. A PR transitions from draft to ready for review
+# 2. Someone explicitly comments "@claude review" on a PR
+# 
+# It will NOT run on:
+# - New commits to existing PRs
+# - Draft PRs
+# - CodeRabbit comments
+# - Other bot comments
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,7 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       github.event.comment &&
        contains(github.event.comment.body, '@claude review') &&
        (github.event.comment.user.type != 'Bot' ||
         contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login)))

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,21 +16,15 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' || 
-        github.event.comment.user.login == 'copilot[bot]' ||
-        github.event.comment.user.login == 'devin[bot]' ||
-        github.event.comment.user.login == 'coderabbitai[bot]')) ||
+        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login))) ||
       (github.event_name == 'pull_request_review_comment' && 
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' ||
-        github.event.comment.user.login == 'copilot[bot]' ||
-        github.event.comment.user.login == 'devin[bot]' ||
-        github.event.comment.user.login == 'coderabbitai[bot]')) ||
+        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login))) ||
       (github.event_name == 'pull_request_review' && 
        contains(github.event.review.body, '@claude') &&
        (github.event.review.user.type != 'Bot' ||
-        github.event.review.user.login == 'copilot[bot]' ||
-        github.event.review.user.login == 'devin[bot]' ||
-        github.event.review.user.login == 'coderabbitai[bot]'))
+        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.review.user.login)))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,8 +5,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -15,6 +13,7 @@ jobs:
     # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans to trigger Claude
     if: |
       (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' || 
         github.event.comment.user.login == 'copilot[bot]' ||
@@ -31,9 +30,7 @@ jobs:
        (github.event.review.user.type != 'Bot' ||
         github.event.review.user.login == 'copilot[bot]' ||
         github.event.review.user.login == 'devin[bot]' ||
-        github.event.review.user.login == 'coderabbitai[bot]')) ||
-      (github.event_name == 'issues' && 
-       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        github.event.review.user.login == 'coderabbitai[bot]'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,9 +76,14 @@ jobs:
           # claude_env: |
           #   NODE_ENV: test
 
-# This workflow responds to explicit @claude mentions
+# This workflow responds to explicit @claude mentions in pull requests only
 # Allowed triggers:
-# - All human comments with @claude
-# - Specific bot comments: @copilot, @devin, @coderabbitai
+# - PR comments with @claude (not regular issues)
+# - PR review comments with @claude
+# - PR review submissions with @claude
+# 
+# Allowed comment sources:
+# - All human users
+# - Specific bots: @copilot, @devin, @coderabbitai
 # All other bots are ignored to prevent unwanted automation loops
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,20 @@ on:
 
 jobs:
   claude:
+    # Only trigger for human comments, not bot comments
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && 
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review_comment' && 
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review' && 
+       contains(github.event.review.body, '@claude') &&
+       github.event.review.user.type != 'Bot') ||
+      (github.event_name == 'issues' && 
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       github.event.issue.user.type != 'Bot')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,4 +70,7 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
+
+# This workflow responds to explicit @claude mentions only
+# It ignores bot comments to prevent infinite loops with CodeRabbit and other bots
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,20 +12,28 @@ on:
 
 jobs:
   claude:
-    # Only trigger for human comments, not bot comments
+    # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans to trigger Claude
     if: |
       (github.event_name == 'issue_comment' && 
        contains(github.event.comment.body, '@claude') &&
-       github.event.comment.user.type != 'Bot') ||
+       (github.event.comment.user.type != 'Bot' || 
+        github.event.comment.user.login == 'copilot[bot]' ||
+        github.event.comment.user.login == 'devin[bot]' ||
+        github.event.comment.user.login == 'coderabbitai[bot]')) ||
       (github.event_name == 'pull_request_review_comment' && 
        contains(github.event.comment.body, '@claude') &&
-       github.event.comment.user.type != 'Bot') ||
+       (github.event.comment.user.type != 'Bot' ||
+        github.event.comment.user.login == 'copilot[bot]' ||
+        github.event.comment.user.login == 'devin[bot]' ||
+        github.event.comment.user.login == 'coderabbitai[bot]')) ||
       (github.event_name == 'pull_request_review' && 
        contains(github.event.review.body, '@claude') &&
-       github.event.review.user.type != 'Bot') ||
+       (github.event.review.user.type != 'Bot' ||
+        github.event.review.user.login == 'copilot[bot]' ||
+        github.event.review.user.login == 'devin[bot]' ||
+        github.event.review.user.login == 'coderabbitai[bot]')) ||
       (github.event_name == 'issues' && 
-       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-       github.event.issue.user.type != 'Bot')
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,6 +79,9 @@ jobs:
           # claude_env: |
           #   NODE_ENV: test
 
-# This workflow responds to explicit @claude mentions only
-# It ignores bot comments to prevent infinite loops with CodeRabbit and other bots
+# This workflow responds to explicit @claude mentions
+# Allowed triggers:
+# - All human comments with @claude
+# - Specific bot comments: @copilot, @devin, @coderabbitai
+# All other bots are ignored to prevent unwanted automation loops
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,22 +11,20 @@ on:
 jobs:
   claude:
     # Allow specific bots (@copilot[bot], @devin[bot], @coderabbitai[bot]) and all humans to trigger Claude
-    env:
-      ALLOWED_BOTS: '["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'
     if: |
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' ||
-        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login))) ||
+        contains(fromJSON('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'), github.event.comment.user.login))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' ||
-        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login))) ||
+        contains(fromJSON('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'), github.event.comment.user.login))) ||
       (github.event_name == 'pull_request_review' &&
        contains(github.event.review.body, '@claude') &&
        (github.event.review.user.type != 'Bot' ||
-        contains(fromJSON(env.ALLOWED_BOTS), github.event.review.user.login)))
+        contains(fromJSON('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'), github.event.review.user.login)))
     runs-on: ubuntu-latest
     concurrency:
       group: claude-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,26 +10,31 @@ on:
 
 jobs:
   claude:
-    # Allow specific bots (@copilot, @devin, @coderabbitai) and all humans to trigger Claude
+    # Allow specific bots (@copilot[bot], @devin[bot], @coderabbitai[bot]) and all humans to trigger Claude
+    env:
+      ALLOWED_BOTS: '["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]'
     if: |
-      (github.event_name == 'issue_comment' && 
+      (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
-       (github.event.comment.user.type != 'Bot' || 
-        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login))) ||
-      (github.event_name == 'pull_request_review_comment' && 
+       (github.event.comment.user.type != 'Bot' ||
+        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login))) ||
+      (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude') &&
        (github.event.comment.user.type != 'Bot' ||
-        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.comment.user.login))) ||
-      (github.event_name == 'pull_request_review' && 
+        contains(fromJSON(env.ALLOWED_BOTS), github.event.comment.user.login))) ||
+      (github.event_name == 'pull_request_review' &&
        contains(github.event.review.body, '@claude') &&
        (github.event.review.user.type != 'Bot' ||
-        contains('["copilot[bot]", "devin[bot]", "coderabbitai[bot]"]', github.event.review.user.login)))
+        contains(fromJSON(env.ALLOWED_BOTS), github.event.review.user.login)))
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -75,9 +80,8 @@ jobs:
 # - PR comments with @claude (not regular issues)
 # - PR review comments with @claude
 # - PR review submissions with @claude
-# 
+#
 # Allowed comment sources:
 # - All human users
-# - Specific bots: @copilot, @devin, @coderabbitai
+# - Specific bots: @copilot[bot], @devin[bot], @coderabbitai[bot]
 # All other bots are ignored to prevent unwanted automation loops
-


### PR DESCRIPTION
- Change claude-code-review.yml to only trigger on ready_for_review
- Add support for manual '@claude review' comments
- Add bot comment filtering to prevent loops with CodeRabbit
- Prevent automatic triggers on every commit to existing PRs
- Add clear documentation about workflow behavior