### PR TITLE
Apply coderabbitai suggestions to update turbo flags

### DIFF
--- a/.agent/docs/monorepo-streamline.md
+++ b/.agent/docs/monorepo-streamline.md
@@ -1213,9 +1213,9 @@ commit-msg:
 pre-push:
   commands:
     types:
-      run: turbo run type-check --affected
+      run: turbo run type-check --filter="[origin/main]"
     test:
-      run: turbo run test --affected
+      run: turbo run test --filter="[origin/main]"
 ```
 
 ### Prettier Config

--- a/docs/research/possible-packages.md
+++ b/docs/research/possible-packages.md
@@ -367,7 +367,7 @@ Here, `outfitter-ci install-and-build` could be a CLI provided by our package th
 **Quick Win v0.1 Tasks:**
 
 - Write a script to set up PNPM on a CI runner (e.g. installing pnpm via corepack or npm). Although GitHub Actions offers `actions/setup-node` with pnpm support, we can encapsulate the steps.
-- Add a script for caching: maybe leveraging `turbo run print-affected` to only run needed builds/tests (or simply rely on turbo's built-in incremental logic).
+- Add a script for caching: maybe leveraging `--filter='[origin/main]'` to only run needed builds/tests (or simply rely on turbo's built-in incremental logic).
 - Provide a basic reusable GitHub Actions workflow YAML in the package (actions allows `uses: ./.github/workflows/xxx.yml@ref` but since our monorepo holds it, we might just document it).
 - Test the CI pipeline on a sample branch to ensure cache hits are happening (perhaps intentionally re-run a workflow to see speed gain).
 - Integrate Biome formatting and Vitest tests into the pipeline via this package's scripts, so that `outfitter-ci` can run "verify" (lint + test) easily. For example, `outfitter-ci verify` runs `pnpm biome check && pnpm turbo run test`. This ensures consistency across projects.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,6 +25,6 @@ commit-msg:
 pre-push:
   commands:
     types:
-      run: bun --filter="*" run type-check
+      run: turbo run type-check --filter=[origin/main]
     test:
-      run: bun --filter="*" run test
+      run: turbo run test --filter=[origin/main]


### PR DESCRIPTION
Replace deprecated Turbo `--affected` flag with `--filter=[origin/main]` in Git hooks and documentation to improve command efficiency.

---
Linear Issue: [MONO-68](https://linear.app/outfitter/issue/MONO-68/replace-deprecated-turbo-affected-with-filter-in-hooksdocs)

<a href="https://cursor.com/background-agent?bcId=bc-3cc82375-1a5a-499e-bb34-99619c6f206d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cc82375-1a5a-499e-bb34-99619c6f206d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

